### PR TITLE
Fixes site complation when no footer menus specified

### DIFF
--- a/layouts/partials/footer-container.html
+++ b/layouts/partials/footer-container.html
@@ -11,15 +11,18 @@
         {{ partial "footer-content" . }}
     </div>
 
-    <div class="col s12 l{{ sub $linksCols 2 }} offset-l2">
-        <div class="row">
-            {{ $menus := .Site.Menus }}
-            {{ $colWidth := math.Floor (div 12 (len .Site.Params.footer_menus)) }}
-            {{ range $index, $menu := .Site.Params.footer_menus }}
-                <div class="col s{{ $colWidth }} clear-padding">
-                    {{ partial "menu-links" (dict "menu" (index $menus $menu.menu) "name" $menu.name ) }}
-                </div>
-            {{ end }}
+    {{ if .Site.Params.footer_menus }}
+        <div class="col s12 l{{ sub $linksCols 2 }} offset-l2">
+            <div class="row">
+                {{ $menus := .Site.Menus }}
+                {{ $colWidth := math.Floor (div 12 (len .Site.Params.footer_menus)) }}
+                {{ range $index, $menu := .Site.Params.footer_menus }}
+                    <div class="col s{{ $colWidth }} clear-padding">
+                        {{ partial "menu-links" (dict "menu" (index $menus $menu.menu) "name" $menu.name ) }}
+                    </div>
+                {{ end }}
+            </div>
         </div>
-    </div>
+    {{ end }}
 </div>
+


### PR DESCRIPTION
If you use this theme but you don't provide `footer_menu` config parameters, then building the site fails:

```
Building sites … ERROR 2018/05/06 13:34:30 Error while rendering "section" in "": template: $SNIPPED/themes/hugo-material-blog/layouts/_default/list.html:36:9: executing "footer" at <partial "footer" .>: error calling partial: template: theme/partials/footer.html:4:15: executing "theme/partials/footer.html" at <partial "footer-cont...>: error calling partial: template: theme/partials/footer-container.html:17:48: executing "theme/partials/footer-container.html" at <len .Site.Params.foo...>: error calling len: len of untyped nil
```

This resolves this issue by not attempting to use `footer_menu` if it's not defined